### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/surround360_design/CONTRIBUTING.md
+++ b/surround360_design/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md).
+
 ## Our Development Process
 
 We maintain a repository for Surround 360 using Facebook's internal infrastructure, which is automatically synched with GitHub.

--- a/surround360_render/CONTRIBUTING.md
+++ b/surround360_render/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md).
+
 ## Our Development Process
 
 We maintain a repository for Surround 360 using Facebook's internal infrastructure, which is automatically synched with GitHub.


### PR DESCRIPTION
Summary:
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [Surround360 community profile
checklist](https://github.com/facebook/Surround360/community) and increase the visibility of our COC.
Closes https://github.com/facebook/Surround360/pull/250

Reviewed By: aparrapo

Differential Revision: D6611712

Pulled By: flarnie

fbshipit-source-id: 32a165ae12d7cc38ee1515748aa004d5531c8725